### PR TITLE
Adding a basic command line interface

### DIFF
--- a/commandline.js
+++ b/commandline.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+var htmlInject = require('./');
+
+// omit the first 2 arguments ('node', 'path')
+argv = process.argv.slice(2);
+
+if (!argv) {
+	console.log("No input arguments specified");
+	process.exit(1);
+
+} else if (argv.length == 1 && argv[0] == "-h") {
+	console.log("usage: cat index.html | htmlinjectscript 'app.js' > output.html");
+	process.exit(0);
+}
+
+process.stdin
+.pipe(htmlInject(argv))
+.pipe(process.stdout);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "bin": {
+    "htmlinjectscript": "commandline.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This is useful when using html-inject-script in a build pipeline using npm scripts.
usage example:

```
cat index.html | htmlinjectscript 'app.js' > output.html
```

Note: this could be extended by using [Commander](https://www.npmjs.com/package/commander), but as the nature of the util is really simple, I felt it to be overkill to introduce another dependency.

Hope you like it... and deploy it so I can use it ;-)

Best,
Diederik.
