### PR TITLE
Add --body and --append options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,33 @@ output:
 <html><head><script src="./app.js"></script><script src="./extra.js"></script></head><body>hello</body></html>
 ```
 
+### api
+
+#### `require('html-inject-script')(scripts[, opts])`
+
+Injects an array of scripts. Accepts an object of options:
+- `selector` (`string`, default: `'head'`): A [hyperstream](https://github.com/substack/hyperstream) selector into which the tags are injected
+- `prepend` (`boolean`, default: `true`): If true, prepends. If false, appends.
+
 ### cli
 
 ```bash
 cat index.html | htmlinjectscript "app.js" > output.html
 ```
 
+```
+usage: cat index.html | htmlinjectscript "app.js" > output.html
+
+Options:
+
+      --body  -b,  inject into the body element (default: head)
+
+   --selector -s,  override head or body with a specific selector
+
+     --append -a,  append to selector instead (default: prepend)
+
+          --help,  -h  display this message
+```
+
 ### Gotcha:
-requires a head tag to be present in the src.
+requires the tag (head, body, or otherwise) to be present in the src.

--- a/cli.js
+++ b/cli.js
@@ -1,36 +1,42 @@
 #!/usr/bin/env node
 
 var htmlInject = require('./')
+var fs = require('fs')
 
 // omit the first 2 arguments ('node', 'path')
-argv = process.argv.slice(2)
+argv = require('minimist')(process.argv.slice(2), {
+  alias: {
+    body: 'b',
+    append: 'a',
+    selector: 's',
+    help: 'h'
+  },
+  default: {
+    body: false,
+    append: false,
+    help: false
+  },
+  boolean: ['h', 'a', 'b']
+})
 
 // no args - fail
-if (!argv.length) {
+if (!argv._.length) {
 	console.log('No input arguments specified...')
   printUsage()
 	process.exit(1)
 // help
-} else if (argv.length == 1 && argv[0] == '-h') {
+} else if (argv.help) {
 	printUsage()
 // stdin -> transform -> stdout
 } else {
-  var selector = null;
-  var idx = argv.indexOf('-b')
-  if (idx !== -1) {
-    argv.splice(idx, 1)
-    selector = 'body'
-  }
-
   process.stdin
-  .pipe(htmlInject(argv, selector))
+  .pipe(htmlInject(argv._, {
+    selector: argv.selector || (argv.body ? 'body' : 'head'),
+    append: argv.append
+  }))
   .pipe(process.stdout)
 }
 
 function printUsage() {
-  console.log([
-    'usage: cat index.html | htmlinjectscript "app.js" > output.html',
-    'flags:',
-    '      -b  append to the body element'
-  ].join('\n'))
+  console.log(fs.readFileSync(__dirname + '/usage.txt', 'utf8'));
 }

--- a/cli.js
+++ b/cli.js
@@ -15,11 +15,22 @@ if (!argv.length) {
 	printUsage()
 // stdin -> transform -> stdout
 } else {
+  var selector = null;
+  var idx = argv.indexOf('-b')
+  if (idx !== -1) {
+    argv.splice(idx, 1)
+    selector = 'body'
+  }
+
   process.stdin
-  .pipe(htmlInject(argv))
+  .pipe(htmlInject(argv, selector))
   .pipe(process.stdout)
 }
 
 function printUsage() {
-  console.log('usage: cat index.html | htmlinjectscript "app.js" > output.html')
+  console.log([
+    'usage: cat index.html | htmlinjectscript "app.js" > output.html',
+    'flags:',
+    '      -b  append to the body element'
+  ].join('\n'))
 }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var SCRIPT_END = '</'+SCRIPT+'>'
 module.exports = transformHtml
 
 function transformHtml(externalTags, opts){
+  opts = opts || {}
+  opts.selector = typeof opts.selector === 'undefined' ? 'head' : opts.selector
   var args = {}
   var op = {}
 

--- a/index.js
+++ b/index.js
@@ -8,15 +8,17 @@ var SCRIPT_END = '</'+SCRIPT+'>'
 
 module.exports = transformHtml
 
+function transformHtml(externalTags, opts){
+  console.log('opts:', opts);
+  var args = {}
+  var op = {}
 
-function transformHtml(externalTags, selector){
-  var args = {};
-  args[selector || 'head'] = {
-    _appendHtml: externalTags.map(function(tag){
-      return SCRIPT_START+' src="'+tag+'">'+SCRIPT_END;
-    }).join('')
-  }
+  op[opts.append ? '_appendHtml' : '_prependHtml'] = externalTags.map(function(tag){
+    return SCRIPT_START+' src="'+tag+'">'+SCRIPT_END;
+  }).join('')
+
+  args[opts.selector] = op
+
   return hyperstream(args);
-
 }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Trumpet = require('trumpet')
+var hyperstream = require('hyperstream')
 
 // this is to avoid the pitfalls of having
 // a script closetag in js inlined in html
@@ -9,22 +9,14 @@ var SCRIPT_END = '</'+SCRIPT+'>'
 module.exports = transformHtml
 
 
-function transformHtml(externalTags){
-
-  var trumpet = Trumpet()
-
-  trumpet.selectAll('head', function (node) {
-    var readStream = node.createReadStream()
-    var writeStream = node.createWriteStream()
-    // insert external tags
-    externalTags.forEach(function(tag){
-      writeStream.write(SCRIPT_START+' src="'+tag+'">'+SCRIPT_END)
-    })
-    // append original content of head
-    readStream.pipe(writeStream)
-  })
-
-  return trumpet
+function transformHtml(externalTags, selector){
+  var args = {};
+  args[selector || 'head'] = {
+    _appendHtml: externalTags.map(function(tag){
+      return SCRIPT_START+' src="'+tag+'">'+SCRIPT_END;
+    }).join('')
+  }
+  return hyperstream(args);
 
 }
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var SCRIPT_END = '</'+SCRIPT+'>'
 module.exports = transformHtml
 
 function transformHtml(externalTags, opts){
-  console.log('opts:', opts);
   var args = {}
   var op = {}
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "hyperstream": "^1.2.2"
-  },
-  "devDependencies": {
+    "hyperstream": "^1.2.2",
     "minimist": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "license": "ISC",
   "dependencies": {
     "trumpet": "^1.7.1"
+  },
+  "devDependencies": {
+    "hyperstream": "^1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "trumpet": "^1.7.1"
+    "hyperstream": "^1.2.2"
   },
   "devDependencies": {
-    "hyperstream": "^1.2.2"
+    "minimist": "^1.2.0"
   }
 }

--- a/usage.txt
+++ b/usage.txt
@@ -1,0 +1,11 @@
+usage: cat index.html | htmlinjectscript "app.js" > output.html
+
+Options:
+
+      --body  -b,  inject into the body element (default: head)
+
+   --selector -s,  override head or body with a specific selector
+
+     --append -a,  append to selector instead (default: prepend)
+
+          --help,  -h  display this message


### PR DESCRIPTION
Love this module! I often find that I need to append a bundle to the body instead of the head though. I've left the existing behavior unchanged by default, but have made the following changes:

- [minimist](https://github.com/substack/minimist) for parsing args
- [hyperstream](https://github.com/substack/hyperstream) (uses trumpet) to simplify things a bit
- `-b` flag to inject into body instead
- `-a` flag to append instead of prepend
- `-s` flag override with specific selector
- corresponding `selector` and `append` api options

I hope that's not too many changes! I'm glad to write tests if desired. Since the default behavior is unchanged though, hopefully it's just couple extra silent bonus features. 🚀